### PR TITLE
Task 12 - Comment_count data returned on articles by id endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,15 @@ Example of call with query: /api/articles?topic=cats
   "exampleResponse": {
     "article": [
       {
-        "article_id": "1",
+        "article_id": 1,
         "title": "Living in the shadow of a great man",
         "topic": "mitch",
         "author": "butter_bridge",
         "body": "I find this existence challenging",
         "created_at": "2020-07-09T20:11:00.000Z",
         "votes": 100,
-        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+		"comment_count": 11
       }
     ]
   }

--- a/__tests__/api.test.js
+++ b/__tests__/api.test.js
@@ -155,6 +155,7 @@ describe("/api/articles/:article_id", () => {
 					votes: 100,
 					article_img_url:
 						"https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+					comment_count: expect.any(Number),
 				});
 			});
 	});

--- a/endpoints.json
+++ b/endpoints.json
@@ -40,7 +40,8 @@
 					"body": "I find this existence challenging",
 					"created_at": "2020-07-09T20:11:00.000Z",
 					"votes": 100,
-					"article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+					"article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+					"comment_count": 11
 				}
 			]
 		}

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -19,7 +19,14 @@ function fetchArticles(topic) {
 
 function fetchArticlesById(article_id) {
 	return db
-		.query("SELECT * FROM articles WHERE article_id = $1", [article_id])
+		.query(
+			`SELECT a.*, count(b.article_id)::int as comment_count FROM articles a 
+			LEFT JOIN comments b
+			ON a.article_id = b.article_id
+			WHERE a. article_id = $1
+			GROUP BY a.article_id`,
+			[article_id]
+		)
 		.then((article) => {
 			if (article.rows.length === 0) {
 				return Promise.reject({


### PR DESCRIPTION
- Implemented the functionality into /api/articles/:articles_id, which now also includes comment_count on the returned object.
- updated readme.md
- updated endpoints.json
